### PR TITLE
[12.0][ADD] automatic generation hr.employee.identification_id

### DIFF
--- a/coopaname_custom/__manifest__.py
+++ b/coopaname_custom/__manifest__.py
@@ -14,7 +14,7 @@
         "hr_employee_firstname",
         "hr_recruitment",
     ],
-    "data": ["views/hr_applicant.xml"],
+    "data": ["views/hr_applicant.xml", "views/hr_employee.xml", "data/data.xml"],
     "demo": [],
     "installable": True,
 }

--- a/coopaname_custom/data/data.xml
+++ b/coopaname_custom/data/data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2019 Coop IT Easy
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <data noupdate="1">
+        <record id="seq_employee_identification_id" model="ir.sequence">
+            <field name="name">Employee Identification Sequence</field>
+            <field name="code">hr.employee.identification_id</field>
+        </record>
+    </data>
+</odoo>

--- a/coopaname_custom/models/__init__.py
+++ b/coopaname_custom/models/__init__.py
@@ -1,1 +1,2 @@
 from . import hr_applicant
+from . import hr_employee

--- a/coopaname_custom/models/hr_employee.py
+++ b/coopaname_custom/models/hr_employee.py
@@ -1,0 +1,61 @@
+# Copyright 2019 Coop IT Easy SCRL fs
+#   Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+import logging
+
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class Employee(models.Model):
+    _inherit = "hr.employee"
+
+    _sql_constraints = [
+        (
+            "identification_id_uniq",
+            "unique(identification_id)",
+            _(
+                "The Employee Identification Number must "
+                "be unique across the company(s)."
+            ),
+        )
+    ]
+
+    @api.model
+    def _generate_identification_id(self, firstname, lastname):
+        try:
+            assert firstname
+            assert lastname
+        except AssertionError:
+            raise ValidationError(
+                _(
+                    "First name and last name are required to generate "
+                    "Identification No "
+                )
+            )
+
+        firstname_initial = firstname[0]
+        if len(lastname.split()) > 1:
+            lastnames = lastname.split()
+            lastname_initials = lastnames[0][0] + lastnames[1][0]
+        else:
+            lastname_initials = lastname[0]
+
+        initials = (firstname_initial + lastname_initials).upper()
+        seq_number = self.env["ir.sequence"].next_by_code(
+            "hr.employee.identification_id"
+        )
+        return "{}{}".format(initials, seq_number)
+
+    @api.model
+    def create(self, values):
+        employee = super().create(values)
+        if not employee.identification_id:
+            employee.identification_id = self._generate_identification_id(
+                employee.firstname, employee.lastname
+            )
+        return employee

--- a/coopaname_custom/readme/DESCRIPTION.rst
+++ b/coopaname_custom/readme/DESCRIPTION.rst
@@ -2,3 +2,4 @@ Customization specific to Coopaname use case.
 
 * copy name from partner_id to hr.applicant name and partner_name
 * hide hr.applicant.name from form view
+* hr.employee: add identification_id generation

--- a/coopaname_custom/tests/test_coopaname_custom.py
+++ b/coopaname_custom/tests/test_coopaname_custom.py
@@ -2,6 +2,7 @@
 #   Robin Keunen <robin@coopiteasy.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from odoo.exceptions import ValidationError
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
@@ -16,3 +17,30 @@ class TestCoopanameCustom(TransactionCase):
 
         self.assertEquals(applicant.name, partner.name)
         self.assertEquals(applicant.partner_name, partner.name)
+
+    def test_generate_employee_identification_id_from_name(self):
+        employee_obj = self.env["hr.employee"]
+        sequence_next = int(
+            self.env.ref("coopaname_custom.seq_employee_identification_id").next_by_id()
+        )
+
+        ernest_id = employee_obj.create(
+            {"firstname": "Ernest", "lastname": "Lapalisse"}
+        ).identification_id
+        self.assertEquals(ernest_id, "EL%s" % (sequence_next + 1))
+
+        sylvaindutilleul_id = employee_obj.create(
+            {"firstname": "Sylvain", "lastname": "Du Tilleul"}
+        ).identification_id
+        self.assertEquals(sylvaindutilleul_id, "SDT%s" % (sequence_next + 2))
+
+        sylvaindutilleul_id = employee_obj.create(
+            {"firstname": "Philippe", "lastname": "De Saxe Cobourg Gotta"}
+        ).identification_id
+        self.assertEquals(sylvaindutilleul_id, "PDS%s" % (sequence_next + 3))
+
+        with self.assertRaises(ValidationError):
+            employee_obj.create({"lastname": "lastname"})
+
+        with self.assertRaises(ValidationError):
+            employee_obj.create({"firstname": "firstname"})

--- a/coopaname_custom/views/hr_employee.xml
+++ b/coopaname_custom/views/hr_employee.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2019 Coop IT Easy
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="view_employee_form" model="ir.ui.view">
+        <field name="name">hr.employee.form.inherit</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.view_employee_form"/>
+        <field name="arch" type="xml">
+            <field name="lastname" position="after">
+                <field name="identification_id"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_employee_tree" model="ir.ui.view">
+        <field name="name">hr.employee.tree.inherit</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.view_employee_tree"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="identification_id"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_employee_filter" model="ir.ui.view">
+        <field name="name">Employees</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.view_employee_filter"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="identification_id"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="hr_kanban_view_employees" model="ir.ui.view">
+        <field name="name">HR - Employees Kanban</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.hr_kanban_view_employees"/>
+        <field name="groups_id" eval="[(6, 0, [ref('hr.group_hr_user') ])]"/>
+        <field name="arch" type="xml">
+            <li id="last_login" position="after">
+                <li t-if="record.identification_id">
+                    <field name="identification_id"/>
+                </li>
+            </li>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Coopaname utilise le module coopaname_gestion_sociale_matricule pour générer des matricules pour les employés.

Plutot que de porter ce module, utiliser les séquence odoo. 

Champs à ajouter:
- Matricule (identification_ID): char selon le pattern:
    - Première lettre du prénom
    - Première(s) lettre(s) du nom, limité à 2 dans le cas d'un nom composé (séparé par un espace)
    - Numéro d'incrément
- Le champs doit être éditable

Exemple: 
- Julien Dussart: JD3, 
- Marc-David Lapalisse: ML48
- Louis Du Pont: LDP42
- Jean De Saxe Cobourg Gotta: JDS987
