### PR TITLE
[IMP] mdh: add record_id to value_log

### DIFF
--- a/member_data_history/README.rst
+++ b/member_data_history/README.rst
@@ -51,6 +51,7 @@ Data is stored in the model `value.log` and its matching table:
     | create_uid     | integer                     |                                                         |
     | create_date    | timestamp without time zone |                                                         |
     | write_uid      | integer                     |                                                         |
+    | record_id      | integer                     |                                                         |
     | write_date     | timestamp without time zone |                                                         |
     +----------------+-----------------------------+---------------------------------------------------------+g
 
@@ -70,6 +71,7 @@ To log a value change, overload `write` like this
                     {
                         "model": "res.partner",
                         "field": "zip",
+                        "record_id", self.id,
                         "previous_value": str(self.zip),
                         "new_value": str(vals.get("zip")),
                     }

--- a/member_data_history/models/hr_contract.py
+++ b/member_data_history/models/hr_contract.py
@@ -18,6 +18,7 @@ class HRContract(models.Model):
                 {
                     "model": "hr.contract",
                     "field": "type_id",
+                    "record_id": self.id,
                     "previous_value": old_type,
                     "new_value": new_type,
                 }
@@ -27,6 +28,7 @@ class HRContract(models.Model):
                 {
                     "model": "hr.contract",
                     "field": "date_start",
+                    "record_id": self.id,
                     "previous_value": self.date_start,
                     "new_value": vals.get("date_start"),
                 }
@@ -36,6 +38,7 @@ class HRContract(models.Model):
                 {
                     "model": "hr.contract",
                     "field": "date_end",
+                    "record_id": self.id,
                     "previous_value": self.date_end,
                     "new_value": vals.get("date_end"),
                 }

--- a/member_data_history/models/hr_employee.py
+++ b/member_data_history/models/hr_employee.py
@@ -2,51 +2,67 @@
 #   Robin Keunen <robin@coopiteasy.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models
-
-
-def format_partner(partner):
-    return "({}, {})".format(partner.id, partner.name)
+from odoo import api, fields, models
 
 
 class Employee(models.Model):
     _inherit = "hr.employee"
 
+    _trigger_field = fields.Boolean(
+        string="internal trigger field", compute="_compute_trigger", store=True
+    )
+
     @api.multi
     def write(self, vals):
         if "address_home_id" in vals:
             if self.address_home_id:
-                old_home_address = format_partner(self.address_home_id)
+                # fixme track zip changes
+                old_home_address = self.address_home_id.zip
             else:
                 old_home_address = False
 
             partner = self.env["res.partner"].browse(vals.get("address_home_id"))
-            new_home_address = format_partner(partner)
 
             self.env["value.log"].create(
                 {
                     "model": "hr.employee",
-                    "field": "address_home_id",
+                    "field": "address_home_id.zip",
+                    "record_id": self.id,
                     "previous_value": old_home_address,
-                    "new_value": new_home_address,
+                    "new_value": partner.zip,
                 }
             )
 
         if "address_id" in vals:
             if self.address_id:
-                old_address = format_partner(self.address_id)
+                old_address = self.address_id.zip
             else:
                 old_address = False
 
             partner = self.env["res.partner"].browse(vals.get("address_id"))
-            new_address = format_partner(partner)
 
             self.env["value.log"].create(
                 {
                     "model": "hr.employee",
-                    "field": "address_id",
+                    "field": "address_id.zip",
+                    "record_id": self.id,
                     "previous_value": old_address,
-                    "new_value": new_address,
+                    "new_value": partner.zip,
                 }
             )
         return super(Employee, self).write(vals)
+
+    @api.depends("address_home_id.zip")
+    def _compute_trigger(self):
+        for employee in self:
+            self.env["value.log"].create(
+                {
+                    "model": "hr.employee",
+                    "field": "address_home_id.zip",
+                    "record_id": employee.id,
+                    "previous_value": "see value log for partner %s"
+                    % employee.address_home_id.id,
+                    "new_value": employee.address_home_id.zip,
+                }
+            )
+            employee._trigger_field = False

--- a/member_data_history/models/res_partner.py
+++ b/member_data_history/models/res_partner.py
@@ -15,6 +15,7 @@ class ResPartner(models.Model):
                 {
                     "model": "res.partner",
                     "field": "zip",
+                    "record_id": self.id,
                     "previous_value": str(self.zip),
                     "new_value": str(vals.get("zip")),
                 }

--- a/member_data_history/models/value_log.py
+++ b/member_data_history/models/value_log.py
@@ -22,5 +22,6 @@ class ValueLog(models.Model):
         default=lambda self: fields.Date.context_today(self),
         required=True,
     )
+    record_id = fields.Integer(string="Record Id")
     previous_value = fields.Char(string="Previous Value")
     new_value = fields.Char(string="New Value")

--- a/member_data_history/readme/USAGE.rst
+++ b/member_data_history/readme/USAGE.rst
@@ -16,6 +16,7 @@ Data is stored in the model `value.log` and its matching table:
     | create_uid     | integer                     |                                                         |
     | create_date    | timestamp without time zone |                                                         |
     | write_uid      | integer                     |                                                         |
+    | record_id      | integer                     |                                                         |
     | write_date     | timestamp without time zone |                                                         |
     +----------------+-----------------------------+---------------------------------------------------------+g
 
@@ -35,6 +36,7 @@ To log a value change, overload `write` like this
                     {
                         "model": "res.partner",
                         "field": "zip",
+                        "record_id", self.id,
                         "previous_value": str(self.zip),
                         "new_value": str(vals.get("zip")),
                     }

--- a/member_data_history/static/description/index.html
+++ b/member_data_history/static/description/index.html
@@ -401,6 +401,7 @@ Logged values are accessible under the configuration tab of the human resources 
 | create_uid     | integer                     |                                                         |
 | create_date    | timestamp without time zone |                                                         |
 | write_uid      | integer                     |                                                         |
+| record_id      | integer                     |                                                         |
 | write_date     | timestamp without time zone |                                                         |
 +----------------+-----------------------------+---------------------------------------------------------+g</span>
 </pre>
@@ -417,6 +418,7 @@ Logged values are accessible under the configuration tab of the human resources 
                 <span class="p">{</span>
                     <span class="s2">&quot;model&quot;</span><span class="p">:</span> <span class="s2">&quot;res.partner&quot;</span><span class="p">,</span>
                     <span class="s2">&quot;field&quot;</span><span class="p">:</span> <span class="s2">&quot;zip&quot;</span><span class="p">,</span>
+                    <span class="s2">&quot;record_id&quot;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">id</span><span class="p">,</span>
                     <span class="s2">&quot;previous_value&quot;</span><span class="p">:</span> <span class="nb">str</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">zip</span><span class="p">),</span>
                     <span class="s2">&quot;new_value&quot;</span><span class="p">:</span> <span class="nb">str</span><span class="p">(</span><span class="n">vals</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s2">&quot;zip&quot;</span><span class="p">)),</span>
                 <span class="p">}</span>

--- a/member_data_history/tests/test_value_log.py
+++ b/member_data_history/tests/test_value_log.py
@@ -36,6 +36,7 @@ class TestValueLog(tests.common.TransactionCase):
             [
                 ("model", "=", "hr.contract"),
                 ("field", "=", "date_end"),
+                ("record_id", "=", contract.id),
                 ("previous_value", "=", False),
                 ("new_value", "=", "2021-11-23"),
             ]
@@ -48,6 +49,7 @@ class TestValueLog(tests.common.TransactionCase):
             [
                 ("model", "=", "hr.contract"),
                 ("field", "=", "type_id"),
+                ("record_id", "=", contract.id),
                 ("previous_value", "=", old_type.name),
                 ("new_value", "=", new_type.name),
             ]
@@ -63,26 +65,29 @@ class TestValueLog(tests.common.TransactionCase):
             [
                 ("model", "=", "res.partner"),
                 ("field", "=", "zip"),
+                ("record_id", "=", partner.id),
                 ("previous_value", "=", str(old_zip)),
                 ("new_value", "=", "4100"),
             ]
         )
         self.assertTrue(log)
 
-    def test_log_employee_adresses(self):
+    def test_log_employee_addresses(self):
         employee = self.browse_ref("hr.employee_hne")
         partner = self.browse_ref("base.res_partner_1")
+
+        previous_home_zip = employee.address_home_id.zip
+        previous_work_zip = employee.address_id.zip
         employee.address_home_id = partner
         employee.address_id = partner
-
-        new_partner = "({}, {})".format(partner.id, partner.name)
 
         log = self.env["value.log"].search(
             [
                 ("model", "=", "hr.employee"),
-                ("field", "=", "address_home_id"),
-                ("previous_value", "=", False),
-                ("new_value", "=", new_partner),
+                ("field", "=", "address_home_id.zip"),
+                ("record_id", "=", employee.id),
+                ("previous_value", "=", previous_home_zip),
+                ("new_value", "=", partner.zip),
             ]
         )
         self.assertTrue(log)
@@ -90,9 +95,10 @@ class TestValueLog(tests.common.TransactionCase):
         log = self.env["value.log"].search(
             [
                 ("model", "=", "hr.employee"),
-                ("field", "=", "address_id"),
-                ("previous_value", "=", False),
-                ("new_value", "=", new_partner),
+                ("field", "=", "address_id.zip"),
+                ("record_id", "=", employee.id),
+                ("previous_value", "=", previous_work_zip),
+                ("new_value", "=", partner.zip),
             ]
         )
         self.assertTrue(log)

--- a/member_data_history/views/value_log.xml
+++ b/member_data_history/views/value_log.xml
@@ -12,6 +12,7 @@
                 <field name="model"/>
                 <field name="field"/>
                 <field name="user_id"/>
+                <field name="record_id"/>
                 <field name="date"/>
                 <field name="previous_value"/>
                 <field name="new_value"/>


### PR DESCRIPTION
It's nice to track values but without the id to trace the record, it's useless.
-> add `record_id` to `value.log`

I also now record the zip of the `employee.adress_home_id` as was originally requested.

And then, I added a compute_method to link the change of partner zip to related employee.