### PR TITLE
Ju partner

### DIFF
--- a/coopaname_custom/models/res_partner.py
+++ b/coopaname_custom/models/res_partner.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api
+
+
+class resPartner(models.Model):
+    _inherit = "res.partner"
+
+    initiate_date = fields.date(
+        string="Date Infocoll",
+        help="A quel moment, la personne fut accueillie par une information collective"
+    )

--- a/coopaname_custom/views/partner.xml
+++ b/coopaname_custom/views/partner.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+ <odoo>
+
+    <record id="coopaname_partner_form" model="ir.ui.view">
+        <field name="name">coopanam.partner.form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="priority">90</field>
+        <field type="xml" name="arch">
+        <xpath expr="//field[@name='function']" position="after">
+                <field name="initiate_date"/>
+            </xpath>


### PR DESCRIPTION
Hey,
J'ai créé un champ initiate_date dans la fiche partenaire pour noter à quel moment ils font une session : information collective.
Cela permet d'éviter d'avoir à créer un candidat à chaque fois pour suivre cette information.

A suivre : le schéma complet du processus d'entrée d'un coopérateur !