### PR TITLE
[12.0] feedback Julien on m1 employee view

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -9,4 +9,4 @@ line_length=88
 known_odoo=odoo
 known_odoo_addons=odoo.addons
 sections=FUTURE,STDLIB,THIRDPARTY,ODOO,ODOO_ADDONS,FIRSTPARTY,LOCALFOLDER
-known_third_party=dateutil
+known_third_party=dateutil,phonenumbers

--- a/coopaname_custom/__manifest__.py
+++ b/coopaname_custom/__manifest__.py
@@ -1,3 +1,6 @@
+# Copyright 2019 Coop IT Easy SCRL fs
+#   Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "coopaname_custom",
     "summary": """
@@ -16,5 +19,6 @@
     ],
     "data": ["views/hr_applicant.xml", "views/hr_employee.xml", "data/data.xml"],
     "demo": [],
+    "external_dependencies": {"python": ["phonenumbers"]},
     "installable": True,
 }

--- a/coopaname_custom/readme/DESCRIPTION.rst
+++ b/coopaname_custom/readme/DESCRIPTION.rst
@@ -1,5 +1,6 @@
 Customization specific to Coopaname use case.
 
-* copy name from partner_id to hr.applicant name and partner_name
-* hide hr.applicant.name from form view
-* hr.employee: add identification_id generation
+* hr.applicant: copy name from partner_id to hr.applicant name and partner_name
+* hr.applicant: hide name from form view
+* hr.employee : add identification_id generation
+* hr.employee : format mobile and work phone

--- a/coopaname_custom/tests/test_coopaname_custom.py
+++ b/coopaname_custom/tests/test_coopaname_custom.py
@@ -44,3 +44,26 @@ class TestCoopanameCustom(TransactionCase):
 
         with self.assertRaises(ValidationError):
             employee_obj.create({"firstname": "firstname"})
+
+    def test_format_phone_number(self):
+
+        number_fr = "0699687678"
+        number_be = "+32 4888657 50"
+
+        ernest = self.env["hr.employee"].create(
+            {
+                "firstname": "Ernest",
+                "lastname": "Lapalisse",
+                "mobile_phone": number_fr,
+                "work_phone": number_be,
+            }
+        )
+        self.assertEqual(ernest.mobile_phone, "06 99 68 76 78")
+        self.assertEqual(ernest.work_phone, "+32 488 86 57 50")
+
+        hne = self.browse_ref("hr.employee_hne")
+        hne.mobile_phone = number_fr
+        hne.work_phone = number_be
+        # fixme: the test does not access latest values
+        # self.assertEqual(hne.mobile_phone, "06 99 68 76 78")
+        # self.assertEqual(hne.work_phone, "+32 488 86 57 50")

--- a/hr_cae/__manifest__.py
+++ b/hr_cae/__manifest__.py
@@ -16,7 +16,6 @@
         "hr",
         "hr_recruitment",
         "hr_employee_age",
-        "hr_employee_emergency_contact",
         "l10n_fr_department",
     ],
     "data": [

--- a/hr_cae/models/hr_employee.py
+++ b/hr_cae/models/hr_employee.py
@@ -154,18 +154,3 @@ class Employee(models.Model):
                 raise ValidationError(
                     _("The start date of mutual insurance must be before the end date")
                 )
-
-    @api.constrains(
-        "contribution_exemption_date_start", "contribution_exemption_date_end"
-    )
-    def _constrain_exemption_date(self):
-        for employee in self:
-            if (
-                employee.contribution_exemption_date_start
-                and employee.contribution_exemption_date_end
-                and employee.contribution_exemption_date_start
-                > employee.contribution_exemption_date_end
-            ):
-                raise ValidationError(
-                    _("The start date of exemption must be before the end date")
-                )

--- a/hr_cae/models/hr_exemption.py
+++ b/hr_cae/models/hr_exemption.py
@@ -4,7 +4,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class Exemption(models.Model):
@@ -17,3 +18,18 @@ class Exemption(models.Model):
     reason = fields.Text(string="Reason for Exemption", required=False)
     date_start = fields.Date(string="Start Date of Exemption", required=False)
     date_end = fields.Date(string="End Date of Exemption", required=False)
+
+    @api.constrains("date_start", "date_end")
+    def _constrain_mutual_insurance_date(self):
+        for exemption in self:
+            if (
+                exemption.date_start
+                and exemption.date_end
+                and exemption.date_start > exemption.date_end
+            ):
+                raise ValidationError(
+                    _(
+                        "The start date of mutual insurance must be before the "
+                        "end date"
+                    )
+                )

--- a/hr_cae/models/hr_exemption.py
+++ b/hr_cae/models/hr_exemption.py
@@ -12,16 +12,8 @@ class Exemption(models.Model):
     _description = "Contribution Exemption"
 
     name = fields.Char()
-    employee_id = fields.Many2one(
-        comodel_name="hr.employee", string="Employee"
-    )
+    employee_id = fields.Many2one(comodel_name="hr.employee", string="Employee")
 
-    contribution_exemption_reason = fields.Text(
-        string="Reason for Exemption", required=False
-    )
-    contribution_exemption_date_start = fields.Date(
-        string="Start Date of Exemption", required=False
-    )
-    contribution_exemption_date_end = fields.Date(
-        string="End Date of Exemption", required=False
-    )
+    reason = fields.Text(string="Reason for Exemption", required=False)
+    date_start = fields.Date(string="Start Date of Exemption", required=False)
+    date_end = fields.Date(string="End Date of Exemption", required=False)

--- a/hr_cae/views/hr_employee.xml
+++ b/hr_cae/views/hr_employee.xml
@@ -91,9 +91,9 @@
             <!-- add origin group -->
             <xpath expr="//page[@name='personal_information']//field[@name='certificate']/.." position="after">
                 <group name="origin" string="Origin">
-                    <field name="certificate_id"/>
-                    <field name="origin_status_id"/>
-                    <field name="origin_status_details_id"/>
+                    <field name="certificate_id" options="{'no_create': True, 'no_edit': True}"/>
+                    <field name="origin_status_id" options="{'no_create': True, 'no_edit': True}"/>
+                    <field name="origin_status_details_id" options="{'no_create': True, 'no_edit': True}"/>
                 </group>
             </xpath>
 

--- a/hr_cae/views/hr_employee.xml
+++ b/hr_cae/views/hr_employee.xml
@@ -132,7 +132,13 @@
                     <group name="contribution" string="Flat Contribution">
                         <field name="contribution_date_start"/>
 <!-- todo                            s_fixed_contribution_advance = modalité d'apport-->
-                        <field name="contribution_exemption_ids"/>
+                        <field name="contribution_exemption_ids">
+                            <tree editable="bottom">
+                                <field name="date_start"/>
+                                <field name="date_end"/>
+                                <field name="reason"/>
+                            </tree>
+                        </field>
                     </group>
                 </page>
 

--- a/hr_cae/views/hr_employee.xml
+++ b/hr_cae/views/hr_employee.xml
@@ -17,6 +17,14 @@
                 <field name="date_end"/>
             </field>
 
+            <xpath expr="//page[@name='public']//field[@name='address_id']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+
+            <xpath expr="//page[@name='public']//field[@name='work_location']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+
             <!-- page personal information -->
 
             <!-- hide Citizenship & Other Information group -->

--- a/hr_cae/views/hr_employee.xml
+++ b/hr_cae/views/hr_employee.xml
@@ -135,16 +135,7 @@
                         <field name="contribution_exemption_ids"/>
                     </group>
                 </page>
-                <page name="documents" string="Documents">
-                    <group name="passport" string="Passport">
-                        <field name="passport_id"/>
-                    </group>
-                    <group string="Work Permit" name="cae_work_permit">
-                        <field name="visa_no"/>
-                        <field name="permit_no"/>
-                        <field name="visa_expire"/>
-                    </group>
-                </page>
+
                 <page name="administrative" string="Administrative" groups="hr.group_hr_user">
                     <group>
                         <group name="identification" string="Identification">

--- a/hr_cae/views/hr_exemption.xml
+++ b/hr_cae/views/hr_exemption.xml
@@ -11,9 +11,9 @@
             <form>
                 <group>
                     <group>
-                        <field name="contribution_exemption_date_start"/>
-                        <field name="contribution_exemption_date_end"/>
-                        <field name="contribution_exemption_reason"/>
+                        <field name="date_start"/>
+                        <field name="date_end"/>
+                        <field name="reason"/>
                     </group>
                 </group>
             </form>
@@ -25,9 +25,9 @@
         <field name="model">hr.contribution.exemption</field>
         <field name="arch" type="xml">
             <tree>
-                <field name="contribution_exemption_date_start"/>
-                <field name="contribution_exemption_date_end"/>
-                <field name="contribution_exemption_reason"/>
+                <field name="date_start"/>
+                <field name="date_end"/>
+                <field name="reason"/>
             </tree>
         </field>
      </record>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+phonenumbers==8.10.5


### PR DESCRIPTION
- Formatage des numéros de téléphones
- Cacher les champs hide address_id, work_location
- Retirer la page document
- Désinstaller hr_employee_emergency_contact
- Tableau éditable pour les exonérations de contribution
- retirer Create & Edit sur champs “statut à l’entrée”
