### PR TITLE
[ADD] hr_cae_contract: termination contract, amendments view, data from employee

### DIFF
--- a/hr_cae_contract/data/hr_contract_data.xml
+++ b/hr_cae_contract/data/hr_contract_data.xml
@@ -22,8 +22,8 @@
         </record>
 
         <!--Accompagnement-->
-        <record id="hr_contract_type_accompaniment" model="hr.contract.type">
-            <field name="name">Accompaniment</field>
+        <record id="hr_contract_type_support" model="hr.contract.type">
+            <field name="name">Support</field>
             <field name="echelon">main</field>
             <field name="sequence">103</field>
         </record>

--- a/hr_cae_contract/data/hr_contract_data.xml
+++ b/hr_cae_contract/data/hr_contract_data.xml
@@ -22,8 +22,8 @@
         </record>
 
         <!--Accompagnement-->
-        <record id="hr_contract_type_coaching" model="hr.contract.type">
-            <field name="name">Coaching</field>
+        <record id="hr_contract_type_accompaniment" model="hr.contract.type">
+            <field name="name">Accompaniment</field>
             <field name="echelon">main</field>
             <field name="sequence">103</field>
         </record>
@@ -91,6 +91,14 @@
             <field name="name">CAPE Remuneration</field>
             <field name="echelon">amendment</field>
             <field name="sequence">208</field>
+        </record>
+
+        <!-- # Termination contract types -->
+        <!--Termination-->
+        <record id="hr_contract_type_termination" model="hr.contract.type">
+            <field name="name">Termination</field>
+            <field name="echelon">termination</field>
+            <field name="sequence">301</field>
         </record>
 
     </data>

--- a/hr_cae_contract/models/hr_contract.py
+++ b/hr_cae_contract/models/hr_contract.py
@@ -87,16 +87,14 @@ class Contract(models.Model):
     _inherit = "hr.contract"
 
     @api.model
-    def _default_type_id(self):
-        return self.env["hr.contract.type"].search(
-            [("name", "=", "Accompaniment")]
-        )
+    def _get_default_type_id(self):
+        return self.env["hr.contract.type"].search([("name", "=", "Support")])
 
     name = fields.Char(compute="_compute_name")
     state = fields.Selection(
         [
             ("draft", "Reception"),
-            ("accompaniment", "Accompaniment"),
+            ("support", "Support"),
             ("social_affairs", "Social Affairs"),
             ("open", "Running"),
             ("pending", "To Renew"),
@@ -121,7 +119,7 @@ class Contract(models.Model):
     type_id = fields.Many2one(
         string="Contract Type",
         domain="[('echelon', '=', echelon)]",
-        default=_default_type_id,
+        default=_get_default_type_id,
         copy=False,
     )  # Todo: rename translation from "Catégorie de l'employé" to "Type de Contrat"
     type_count = fields.Integer(

--- a/hr_cae_contract/models/hr_contract.py
+++ b/hr_cae_contract/models/hr_contract.py
@@ -50,15 +50,28 @@ class ContractGroup(models.Model):
             limit=1,
         )
 
+    def has_termination_contract(self):
+        return bool(
+            self.contract_ids.search(
+                [
+                    ("contract_group_id", "=", self.id),
+                    ("echelon", "=", "termination"),
+                ]
+            )
+        )
+
 
 class ContractType(models.Model):
 
     _inherit = "hr.contract.type"
 
     echelon = fields.Selection(
-        [("main", "Main"), ("amendment", "Amendment")],
+        [
+            ("main", "Main"),
+            ("amendment", "Amendment"),
+            ("termination", "Termination"),
+        ],
         string="Echelon",
-        default="main",
     )
     max_usage = fields.Integer(string="Maximum Usage", default=False)
 
@@ -73,21 +86,42 @@ class ContractTag(models.Model):
 class Contract(models.Model):
     _inherit = "hr.contract"
 
+    @api.model
+    def _default_type_id(self):
+        return self.env["hr.contract.type"].search(
+            [("name", "=", "Accompaniment")]
+        )
+
     name = fields.Char(compute="_compute_name")
-    state = fields.Selection(copy=False)
+    state = fields.Selection(
+        [
+            ("draft", "Reception"),
+            ("accompaniment", "Accompaniment"),
+            ("social_affairs", "Social Affairs"),
+            ("open", "Running"),
+            ("pending", "To Renew"),
+            ("close", "Expired"),
+            ("termination", "Terminated"),
+            ("cancel", "Cancelled"),
+        ],
+        copy=False,
+    )
     employee_id = fields.Many2one(required=True)
-    type_echelon = fields.Selection(
-        [("main", "Main"), ("amendment", "Amendment")],
+    echelon = fields.Selection(
+        [
+            ("main", "Main"),
+            ("amendment", "Amendment"),
+            ("termination", "Termination"),
+        ],
         default="main",
         string="Contract Type Echelon",
+        readonly=True,
         copy=False,
-        compute="_compute_type_echelon",
-        store=True,
     )  # Todo: add translation "Échelon du Type de Contrat"
     type_id = fields.Many2one(
         string="Contract Type",
-        domain="[('echelon', '=', type_echelon)]",
-        default="",
+        domain="[('echelon', '=', echelon)]",
+        default=_default_type_id,
         copy=False,
     )  # Todo: rename translation from "Catégorie de l'employé" to "Type de Contrat"
     type_count = fields.Integer(
@@ -112,9 +146,6 @@ class Contract(models.Model):
         string="Mailing Date", help="Mailing date of the contract.", copy=False
     )
 
-    hours = fields.Float(string="Working Hours", required=True)
-    hourly_wage = fields.Monetary(string="Hourly Wage", required=True)
-    turnover_minimum = fields.Monetary(string="Minimum Turn-Over")
     wage = fields.Monetary(
         string="Wage",
         digits=(16, 2),
@@ -123,6 +154,9 @@ class Contract(models.Model):
         help="Employee's monthly gross wage.",
         compute="_compute_wage",
     )
+    hours = fields.Float(string="Working Hours", required=True)
+    hourly_wage = fields.Monetary(string="Hourly Wage", required=True)
+    turnover_minimum = fields.Monetary(string="Minimum Turn-Over")
 
     amendment_index = fields.Integer(
         string="Amendment Index",
@@ -134,7 +168,7 @@ class Contract(models.Model):
     contract_group_id = fields.Many2one(
         comodel_name="hr.contract.group", string="Contract Group"
     )
-    contract_group_contract_ids = fields.One2many(
+    contract_ids = fields.One2many(
         comodel_name="hr.contract", related="contract_group_id.contract_ids"
     )
     initial_contract_id = fields.Many2one(
@@ -162,6 +196,11 @@ class Contract(models.Model):
         readonly=True,
         compute="_compute_latest",
     )
+    has_termination_contract = fields.Boolean(
+        string="Has Termination Contract",
+        readonly=True,
+        compute="_compute_has_termination_contract",
+    )
 
     notes = fields.Text(copy=False)
 
@@ -184,6 +223,26 @@ class Contract(models.Model):
         if res.amendment_index == 0:
             res._compute_initial()
         return res
+
+    # Alternative for onchange (see below) such that it works on every write
+    @api.multi
+    def write(self, vals):
+        res = super(Contract, self).write(vals)
+        for contract in self:
+            if (
+                bool(vals.get("state"))
+                and contract.echelon == "termination"
+                and contract.state == "open"
+            ):
+                other_contracts = contract.contract_ids - contract
+                other_contracts.write({"state": "termination"})
+        return res
+
+    # @api.onchange("state")
+    # def onchange_state(self):
+    #     if self.echelon == "termination" and self.state == "open":
+    #         other_contracts = self.contract_ids - self._origin
+    #         other_contracts.write({"state": "termination"})
 
     @api.multi
     @api.depends("employee_id", "initial_contract_id", "type_id")
@@ -210,19 +269,11 @@ class Contract(models.Model):
             )
 
     @api.multi
-    @api.depends("amendment_index")
-    def _compute_type_echelon(self):
-        for contract in self:
-            contract.type_echelon = (
-                "main" if contract.amendment_index == 0 else "amendment"
-            )
-
-    @api.multi
-    @api.depends("contract_group_contract_ids", "type_id")
+    @api.depends("contract_ids", "type_id")
     def _compute_type_count(self):
         for contract in self:
             type_count = 0
-            for c in contract.contract_group_contract_ids:
+            for c in contract.contract_ids:
                 if c.type_id == contract.type_id:
                     type_count += 1
             contract.type_count = type_count
@@ -255,6 +306,12 @@ class Contract(models.Model):
         for contract in self:
             contract.latest_contract_id = (
                 contract.contract_group_id.get_latest()
+            )
+
+    def _compute_has_termination_contract(self):
+        for contract in self:
+            contract.has_termination_contract = (
+                contract.contract_group_id.has_termination_contract()
             )
 
     @api.multi
@@ -301,6 +358,13 @@ class Contract(models.Model):
             rd = relativedelta(self.date_end, self.date_start)
             self.duration = rd.months + rd.years * 12
 
+    @api.onchange("employee_id")
+    def onchange_employee_id(self):
+        if self.employee_id.turnover_minimum:
+            self.turnover_minimum = self.employee_id.turnover_minimum
+        if self.employee_id.date_start:
+            self.date_start = self.employee_id.date_start
+
     #  Note: this check must run both when creating a new amendment
     #  and when changing the type_id of an amendment
     @api.multi
@@ -321,30 +385,47 @@ class Contract(models.Model):
 
     def create_amendment(self, type_id):
         self.ensure_one()
+        return self._create_contract("amendment", type_id)
+
+    def create_termination(self):
+        self.ensure_one()
+        type_id = self.env.ref("hr_cae_contract.hr_contract_type_termination")
+        return self._create_contract("termination", type_id)
+
+    def _create_contract(self, echelon, type_id):
+        self.ensure_one()
+        if self.has_termination_contract:
+            raise ValidationError(
+                _("This contract group already has a termination contract ")
+            )
         if not type_id:
             type_id = self.env["hr.contract.type"].search(
-                [("echelon", "=", "amendment")], limit=1
+                [("echelon", "=", echelon)], limit=1
             )
 
-        _logger.info("Creating %s Amendment" % type_id.name)
+        _logger.info(
+            "Creating Contract of echelon %s and type %s."
+            % (echelon, type_id.name)
+        )
 
         latest_contract_id = self.latest_contract_id
-        amendment = latest_contract_id.copy(
+        contract = latest_contract_id.copy(
             {
                 "state": "draft",
+                "echelon": echelon,
                 "type_id": type_id.id,
                 "duration": False,
                 "date_end": False,
                 "amendment_index": latest_contract_id.amendment_index + 1,
             }
         )
-        amendment.check_type_count()
+        contract.check_type_count()
 
         return {
             "type": "ir.actions.act_window",
             "res_model": "hr.contract",
             "view_mode": "form",
-            "res_id": amendment.id,
+            "res_id": contract.id,
             "target": "current",
             "context": {"form_view_initial_mode": "edit"},
         }

--- a/hr_cae_contract/tests/test_hr_cae_contract.py
+++ b/hr_cae_contract/tests/test_hr_cae_contract.py
@@ -14,6 +14,9 @@ class TestHRContractCAE(TransactionCase):
         self.cape_renewal = self.browse_ref(
             "hr_cae_contract.hr_contract_type_cape_renewal"
         )
+        self.termination = self.browse_ref(
+            "hr_cae_contract.hr_contract_type_termination"
+        )
         self.contract = self.env["hr.contract"].create(
             {
                 "employee_id": self.employee.id,
@@ -43,7 +46,7 @@ class TestHRContractCAE(TransactionCase):
         amendment_1_id = wizard_1.create_amendment()["res_id"]
         amendment_1 = self.env["hr.contract"].browse(amendment_1_id)
 
-        self.assertEquals(amendment_1.type_echelon, "amendment")
+        self.assertEquals(amendment_1.echelon, "amendment")
         self.assertEquals(amendment_1.initial_contract_id, self.contract)
         self.assertEquals(amendment_1.amendment_index, 1)
         self.assertEquals(amendment_1.parent_contract_id, self.contract)
@@ -62,7 +65,7 @@ class TestHRContractCAE(TransactionCase):
         amendment_2_id = wizard_2.create_amendment()["res_id"]
         amendment_2 = self.env["hr.contract"].browse(amendment_2_id)
 
-        self.assertEquals(amendment_2.type_echelon, "amendment")
+        self.assertEquals(amendment_2.echelon, "amendment")
         self.assertEquals(amendment_2.initial_contract_id, self.contract)
         self.assertEquals(amendment_2.amendment_index, 2)
         self.assertEquals(amendment_2.parent_contract_id, amendment_1)
@@ -82,3 +85,23 @@ class TestHRContractCAE(TransactionCase):
                 )
             )
             wizard_3.create_amendment()
+
+    def test_termination(self):
+        wizard_1 = (
+            self.env["hr.contract.amendment.wizard"]
+            .with_context({"active_id": self.contract.id})
+            .create(
+                {
+                    "contract_id": self.contract.id,
+                    "type_id": self.cape_renewal.id,
+                }
+            )
+        )
+        amendment_1_id = wizard_1.create_amendment()["res_id"]
+        amendment_1 = self.env["hr.contract"].browse(amendment_1_id)
+
+        termination_1_id = self.contract.create_termination()["res_id"]
+        termination_1 = self.env["hr.contract"].browse(termination_1_id)
+
+        termination_1.state = "open"
+        self.assertEquals(amendment_1.state, "termination")

--- a/hr_cae_contract/views/hr_contract.xml
+++ b/hr_cae_contract/views/hr_contract.xml
@@ -98,12 +98,6 @@
             <xpath expr="//page[@name='information']" position="after">
                 <page string="Amendments" name="tree">
                     <group>
-                                                <group>
-                            <field name="initial_contract_id"/>
-                            <field name="parent_contract_id"/>
-                            <field name="child_contract_id"/>
-                            <field name="latest_contract_id"/>
-                        </group>
                         <field name="has_termination_contract" invisible="1"/>
                         <field name="contract_ids" nolabel="1" context="{'tree_view_ref': 'hr_cae_contract.hr_contract_details_view_tree'}"/>
                     </group>

--- a/hr_cae_contract/views/hr_contract.xml
+++ b/hr_cae_contract/views/hr_contract.xml
@@ -12,8 +12,14 @@
 
             <field name="state" position="before">
                 <button name="%(create_amendment_wizard_view_action)d"
-                        string="Create Amendment"
+                        string="Create Amendment Contract"
                         type="action"
+                        attrs="{'invisible': [('has_termination_contract', '=', True)]}"
+                        class="oe_read_only"/>
+                <button name="create_termination"
+                        string="Create Termination Contract"
+                        type="object"
+                        attrs="{'invisible': [('has_termination_contract', '=', True)]}"
                         class="oe_read_only"/>
             </field>
 
@@ -24,16 +30,20 @@
             </button>
 
             <field name="employee_id" position="attributes">
-                <attribute name="attrs">{'readonly':[('type_echelon', '=', 'amendment')]}</attribute>
+                <attribute name="attrs">{'readonly':[('echelon', '!=', 'main')]}</attribute>
             </field>
 
             <field name="job_id" position="after">
                 <field name="date_initial_start"/>
             </field>
 
+            <field name="type_id" position="attributes">
+                <attribute name="options">{'no_create': True}</attribute>
+            </field>
+
             <field name="type_id" position="before">
                 <div style="width:35%"/> <!--Managing label width-->
-                <field name="type_echelon"/>
+                <field name="echelon"/>
             </field>
 
             <field name="type_id" position="after">
@@ -88,13 +98,14 @@
             <xpath expr="//page[@name='information']" position="after">
                 <page string="Amendments" name="tree">
                     <group>
-<!--                        <group>-->
-<!--                            <field name="initial_contract_id"/>-->
-<!--                            <field name="parent_contract_id"/>-->
-<!--                            <field name="child_contract_id"/>-->
-<!--                            <field name="latest_contract_id"/>-->
-<!--                        </group>-->
-                        <field name="contract_group_contract_ids" nolabel="1"/>
+                                                <group>
+                            <field name="initial_contract_id"/>
+                            <field name="parent_contract_id"/>
+                            <field name="child_contract_id"/>
+                            <field name="latest_contract_id"/>
+                        </group>
+                        <field name="has_termination_contract" invisible="1"/>
+                        <field name="contract_ids" nolabel="1" context="{'tree_view_ref': 'hr_cae_contract.hr_contract_details_view_tree'}"/>
                     </group>
                 </page>
             </xpath>
@@ -109,15 +120,38 @@
         <field name="arch" type="xml">
 
             <field name="type_id" position="before">
-                <field name="type_echelon"/>
                 <field name="amendment_index"/>
+                <field name="echelon"/>
             </field>
 
             <field name="resource_calendar_id" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
 
+            <field name="date_end" position="after">
+                <field name="state"/>
+            </field>
 
+
+        </field>
+    </record>
+
+    <record id="hr_contract_details_view_tree" model="ir.ui.view">
+        <field name="name">hr_contract_details_view_tree</field>
+        <field name="model">hr.contract</field>
+        <field name="arch" type="xml">
+            <tree decoration-muted="state=='termination'" default_order="amendment_index desc">
+                <field name="amendment_index"/>
+                <field name="echelon"/>
+                <field name="type_id"/>
+                <field name="wage"/>
+                <field name="hours"/>
+                <field name="hourly_wage"/>
+                <field name="turnover_minimum"/>
+                <field name="date_start"/>
+                <field name="date_end"/>
+                <field name="state"/>
+            </tree>
         </field>
     </record>
 
@@ -150,7 +184,7 @@
             <field name="res_model">hr.contract</field>
             <field name="view_type">form</field>
             <field name="view_mode">kanban,tree,form,activity</field>
-            <field name="domain">[('employee_id', '!=', False), ('type_echelon', '=', 'main')]</field>
+            <field name="domain">[('employee_id', '!=', False), ('echelon', '=', 'main')]</field>
             <field name="context">{'search_default_current':1, 'search_default_group_by_state': 1}</field>
             <field name="search_view_id" ref="hr_contract.hr_contract_view_search"/>
             <field name="help" type="html">
@@ -165,7 +199,22 @@
             <field name="res_model">hr.contract</field>
             <field name="view_type">form</field>
             <field name="view_mode">kanban,tree,form,activity</field>
-            <field name="domain">[('employee_id', '!=', False), ('type_echelon', '=', 'amendment')]</field>
+            <field name="domain">[('employee_id', '!=', False), ('echelon', '=', 'amendment')]</field>
+            <field name="context">{'search_default_current':1, 'search_default_group_by_state': 1}</field>
+            <field name="search_view_id" ref="hr_contract.hr_contract_view_search"/>
+            <field name="help" type="html">
+              <p class="o_view_nocontent_smiling_face">
+                Create a new contract
+              </p>
+            </field>
+        </record>
+
+    <record id="action_hr_contract_termination" model="ir.actions.act_window">
+            <field name="name">Contracts</field>
+            <field name="res_model">hr.contract</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">kanban,tree,form,activity</field>
+            <field name="domain">[('employee_id', '!=', False), ('echelon', '=', 'termination')]</field>
             <field name="context">{'search_default_current':1, 'search_default_group_by_state': 1}</field>
             <field name="search_view_id" ref="hr_contract.hr_contract_view_search"/>
             <field name="help" type="html">
@@ -176,17 +225,20 @@
         </record>
 
     <menuitem id="menu_hr_contracts" name="Contracts" parent="hr.menu_hr_root" groups="hr_contract.group_hr_contract_manager" sequence="4"/>
-    <menuitem id="menu_hr_contracts_all" name="All contracts" parent="menu_hr_contracts" action="hr_contract.action_hr_contract" sequence="1"/>
-    <menuitem id="menu_hr_contracts_main" name="Main contracts" parent="menu_hr_contracts" action="action_hr_contract_main" sequence="2"/>
-    <menuitem id="menu_hr_contracts_amendment" name="Amendment contracts" parent="menu_hr_contracts" action="action_hr_contract_amendment" sequence="3"/>
+    <menuitem id="menu_hr_contracts_all" name="All Contracts" parent="menu_hr_contracts" action="hr_contract.action_hr_contract" sequence="1"/>
+    <menuitem id="menu_hr_contracts_main" name="Main Contracts" parent="menu_hr_contracts" action="action_hr_contract_main" sequence="2"/>
+    <menuitem id="menu_hr_contracts_amendment" name="Amendment Contracts" parent="menu_hr_contracts" action="action_hr_contract_amendment" sequence="3"/>
+    <menuitem id="menu_hr_contracts_termination" name="Termination Contracts" parent="menu_hr_contracts" action="action_hr_contract_termination" sequence="4"/>
 
-    <!-- Overriding menu's of hr_contract to change group of type menu to show it and to hide the main contract menu -->
+    <!-- Overriding menu's of hr_contract to -->
+    <!-- Change group of the type menuitem to have it appear -->
     <menuitem
             id="hr_contract.hr_menu_contract_type"
             action="hr_contract.action_hr_contract_type"
             parent="hr.menu_human_resources_configuration"
             sequence="3"
             groups="hr_contract.group_hr_contract_manager"/>
+    <!-- Remove the groups from the normal Contracts menuitem to have it disappear (replaced by menu_hr_contracts) -->
     <menuitem
         id="hr_contract.hr_menu_contract"
         name="Contracts"


### PR DESCRIPTION
- This adds way to terminate contracts: next to ammendments, a 'termination contract' can be added. When it is put in state 'running', all other contracts in the contract group are terminated.
- The contract group view is expanded to easily see how wage evolves over contracts
- Some data is ported from the employee when a contract is made.
- Some fields were renamed and some small UI enhancements are added.

Question: I initially programmed the first functionallity listed above with an onchange but 1) this means it only works when the state is changed in that contract's form view (not when in a kanban view or when through a database write) and 2) I don't know how to test onchange. So I did it with a check on the write function (old onchange still commented out below). Would like your opions!