### PR TITLE
[ADD] hr_cae_contract: ongoing contract types tags on employees

### DIFF
--- a/hr_cae_contract/__manifest__.py
+++ b/hr_cae_contract/__manifest__.py
@@ -17,6 +17,7 @@
         "data/hr_contract_data.xml",
         "wizard/create_amendment_wizard.xml",
         "views/hr_contract.xml",
+        "views/hr_employee.xml",
     ],
     "demo": [],
     "installable": True,

--- a/hr_cae_contract/models/__init__.py
+++ b/hr_cae_contract/models/__init__.py
@@ -1,1 +1,2 @@
 from . import hr_contract
+from . import hr_employee

--- a/hr_cae_contract/models/hr_contract.py
+++ b/hr_cae_contract/models/hr_contract.py
@@ -74,6 +74,20 @@ class ContractType(models.Model):
         string="Echelon",
     )
     max_usage = fields.Integer(string="Maximum Usage", default=False)
+    color = fields.Integer(string="Color Index", compute="_compute_color")
+
+    @api.multi
+    @api.depends("echelon")
+    def _compute_color(self):
+        for type in self:
+            if type.echelon == "main":
+                type.color = 7  # Dark blue
+            elif type.echelon == "amendment":
+                type.color = 4  # Light blue
+            elif type.echelon == "termination":
+                type.color = 1  # Orange
+            else:
+                type.color = 0  # White
 
 
 class ContractTag(models.Model):

--- a/hr_cae_contract/models/hr_employee.py
+++ b/hr_cae_contract/models/hr_employee.py
@@ -1,0 +1,33 @@
+# Copyright 2019 Coop IT Easy SCRL fs
+#   Manuel Claeys Bouuaert <manuel@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class Employee(models.Model):
+    _inherit = "hr.employee"
+
+    contract_ids = fields.One2many(
+        comodel_name="hr.contract",
+        inverse_name="employee_id",
+        string="Contracts",
+    )
+    ongoing_contract_type_ids = fields.Many2many(
+        comodel_name="hr.contract.type",
+        string="Contract Types",
+        compute="_compute_ongoing_contract_type_ids",
+    )
+
+    @api.multi
+    @api.depends("contract_ids", "contract_ids.state", "contract_ids.type_id")
+    def _compute_ongoing_contract_type_ids(self):
+        for employee in self:
+            employee.ongoing_contract_type_ids = (
+                employee.contract_ids.filtered(
+                    lambda c: c.state in ["open", "pending"]
+                    and c.echelon in ["main", "amendment"]
+                )
+                .mapped("type_id")
+                .sorted(lambda t: t.sequence)
+            )

--- a/hr_cae_contract/models/hr_employee.py
+++ b/hr_cae_contract/models/hr_employee.py
@@ -15,8 +15,9 @@ class Employee(models.Model):
     )
     ongoing_contract_type_ids = fields.Many2many(
         comodel_name="hr.contract.type",
-        string="Contract Types",
+        string="Ongoing Contract Types",
         compute="_compute_ongoing_contract_type_ids",
+        store=True,
     )
 
     @api.multi

--- a/hr_cae_contract/views/hr_employee.xml
+++ b/hr_cae_contract/views/hr_employee.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2019 Coop IT Easy
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="view_employee_form" model="ir.ui.view">
+        <field name="name">hr.employee.form</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.view_employee_form"/>
+        <field name="arch" type="xml">
+
+            <field name="category_ids" position="after">
+                <field name="ongoing_contract_type_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+            </field>
+
+        </field>
+    </record>
+</odoo>

--- a/hr_cae_contract/views/hr_employee.xml
+++ b/hr_cae_contract/views/hr_employee.xml
@@ -17,4 +17,18 @@
 
         </field>
     </record>
+
+    <record id="view_employee_kanban" model="ir.ui.view">
+        <field name="name">hr.employee.kanban</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.hr_kanban_view_employees"/>
+        <field name="arch" type="xml">
+
+            <field name="category_ids" position="after">
+                <field name="ongoing_contract_type_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+            </field>
+
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Adds colored 'ongoing contract types tags' on employees, at the same place of category_ids.

Only disadvantage could be that with category_id and this next to each other there could be confusion.