### PR TITLE
[12.0][ADD] M1b: Employee Link

### DIFF
--- a/coopaname_custom/models/hr_employee.py
+++ b/coopaname_custom/models/hr_employee.py
@@ -44,11 +44,15 @@ class Employee(models.Model):
 
         employee = super().create(values)
         if not employee.address_home_id:
+            address_home_ids = (
+                self.env["hr.employee"].search([]).mapped("address_home_id.id")
+            )
             partner = self.env["res.partner"].search(
                 [
                     ("email", "!=", False),
                     ("email", "=", employee.work_email),
                     ("is_company", "=", False),
+                    ("id", "not in", address_home_ids),
                 ],
                 limit=1,
             )

--- a/coopaname_custom/tests/test_coopaname_custom.py
+++ b/coopaname_custom/tests/test_coopaname_custom.py
@@ -85,3 +85,26 @@ class TestCoopanameCustom(TransactionCase):
         )
         self.assertTrue(group_id in employee_user.groups_id)
         self.assertEqual(employee_user.company_id, company_id)
+
+    def test_create_employee_finds_partner(self):
+        partner = self.env["res.partner"].create(
+            {"name": "Test man", "email": "test_create_employee@example.com"}
+        )
+        employee = self.env["hr.employee"].create(
+            {
+                "name": "Test man",
+                "work_email": "test_create_employee@example.com",
+            }
+        )
+        self.assertTrue(employee.address_home_id)
+        self.assertEqual(employee.address_home_id, partner)
+
+    def test_create_employee_has_address_home_id(self):
+        employee = self.env["hr.employee"].create(
+            {
+                "name": "Test man",
+                "work_email": "test_create_employee@example.com",
+            }
+        )
+        self.assertTrue(employee.address_home_id)
+        self.assertEqual(employee.address_home_id.email, employee.work_email)


### PR DESCRIPTION
Since the client wants to enter timesheet lines for employee's using their `parter_id` field, we want to be more sure that there is such a field (without making it required, because that could cause troubles on import and might be to strict of an approach).

We build on the employee's `address_home_id` field, which references a partner. In case the employee is created from an applicant with a `contact_id` (`res.partner`), this link is passed to `address_home_id`.

Here, we assure that a `address_home_id` is present on creation - if not already, we search for partners with the email address as key or create a new one.

Also, we improve passing on the link to the partner when creating a user from an employee.

This builds on #27 