### PR TITLE
[FIX] migrate thumbnail to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/odoo-cae/odoo-addons-hr-incubator.svg?branch=12.0)](https://travis-ci.org/odoo-cae/odoo-addons-hr-incubator?branch=12.0)
+[![Build Status](https://travis-ci.com/odoo-cae/odoo-addons-hr-incubator.svg?branch=12.0)](https://travis-ci.com/odoo-cae/odoo-addons-hr-incubator?branch=12.0)
 [![Coverage Status](https://coveralls.io/repos/github/odoo-cae/odoo-addons-hr-incubator/badge.svg?branch=12.0)](https://coveralls.io/github/odoo-cae/odoo-addons-hr-incubator?branch=12.0)
 [![Code Climate](https://codeclimate.com/github/odoo-cae/odoo-addons-hr-incubator/badges/gpa.svg)](https://codeclimate.com/github/odoo-cae/odoo-addons-hr-incubator)
 


### PR DESCRIPTION
Hi there,

Travis is shutting down travis-ci.org in December 2020. Everything will be move to travis-ci.com. The info and procedure is [here](https://docs.travis-ci.com/user/migrate/open-source-repository-migration).

As i understand, you should have access to a _migrate_ button in travis-ci.org. Can one of you do that?

kusjes