### PR TITLE
[12.0] fix event import

### DIFF
--- a/hr_cae_event/README.rst
+++ b/hr_cae_event/README.rst
@@ -13,15 +13,16 @@ HR CAE Event
 .. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
-.. |badge3| image:: https://img.shields.io/badge/github-odoo-cae%2Fodoo--addons--hr--incubator-lightgray.png?logo=github
-    :target: https://github.com/odoo-cae/odoo-addons-hr-incubator/tree/12.0/hr_cae_event
-    :alt: odoo-cae/odoo-addons-hr-incubator
+.. |badge3| image:: https://img.shields.io/badge/github-odoo_cae%2Fodoo--addons--hr--incubator-lightgray.png?logo=github
+    :target: https://github.com/odoo_cae/odoo-addons-hr-incubator/tree/12.0/hr_cae_event
+    :alt: odoo_cae/odoo-addons-hr-incubator
 
 |badge1| |badge2| |badge3| 
 
 Manage HR events in a CAE.
 
 * Adds fields to standard events to organize information session.
+* Facilitate event and event registration imports by remove field-based restriction readonly on 'status' field (add add it as view-based ristriction where needed).
 
 **Table of contents**
 
@@ -31,10 +32,10 @@ Manage HR events in a CAE.
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/odoo-cae/odoo-addons-hr-incubator/issues>`_.
+Bugs are tracked on `GitHub Issues <https://github.com/odoo_cae/odoo-addons-hr-incubator/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
-`feedback <https://github.com/odoo-cae/odoo-addons-hr-incubator/issues/new?body=module:%20hr_cae_event%0Aversion:%2012.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/odoo_cae/odoo-addons-hr-incubator/issues/new?body=module:%20hr_cae_event%0Aversion:%2012.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -54,6 +55,6 @@ Contributors
 Maintainers
 ~~~~~~~~~~~
 
-This module is part of the `odoo-cae/odoo-addons-hr-incubator <https://github.com/odoo-cae/odoo-addons-hr-incubator/tree/12.0/hr_cae_event>`_ project on GitHub.
+This module is part of the `odoo_cae/odoo-addons-hr-incubator <https://github.com/odoo_cae/odoo-addons-hr-incubator/tree/12.0/hr_cae_event>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/hr_cae_event/models/event.py
+++ b/hr_cae_event/models/event.py
@@ -52,6 +52,12 @@ class Event(models.Model):
 
         return res
 
+    @api.multi
+    def confirm_registrations(self):
+        for event in self:
+            for registration in event.registration_ids:
+                registration.confirm_registration()
+
 
 class EventRegistration(models.Model):
     _inherit = "event.registration"

--- a/hr_cae_event/models/event.py
+++ b/hr_cae_event/models/event.py
@@ -29,6 +29,7 @@ class Event(models.Model):
         help="hours",
     )
     co_organizer_id = fields.Many2one("res.partner", string="Co-Organizer")
+    state = fields.Selection(readonly=False)
 
     @api.depends("date_begin", "date_end")
     @api.multi
@@ -58,6 +59,7 @@ class EventRegistration(models.Model):
     employee_id = fields.Many2one(
         comodel_name="hr.employee", string="Employee", required=False
     )
+    state = fields.Selection(readonly=False)
 
     @api.onchange("employee_id")
     def _onchange_employee_id(self):

--- a/hr_cae_event/readme/DESCRIPTION.rst
+++ b/hr_cae_event/readme/DESCRIPTION.rst
@@ -1,3 +1,4 @@
 Manage HR events in a CAE.
 
 * Adds fields to standard events to organize information session.
+* Facilitate event and event registration imports by remove field-based restriction readonly on 'status' field (add add it as view-based ristriction where needed).

--- a/hr_cae_event/static/description/index.html
+++ b/hr_cae_event/static/description/index.html
@@ -371,6 +371,7 @@ ul.auto-toc {
 <p>Manage HR events in a CAE.</p>
 <ul class="simple">
 <li>Adds fields to standard events to organize information session.</li>
+<li>Facilitate event and event registration imports by remove field-based restriction readonly on ‘status’ field (add add it as view-based ristriction where needed).</li>
 </ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">

--- a/hr_cae_event/views/event.xml
+++ b/hr_cae_event/views/event.xml
@@ -86,4 +86,16 @@
             </field>
         </field>
     </record>
+
+    <record id="ir_actions_event_confirm_registrations" model="ir.actions.server">
+        <field name="name">Confirm Registrations</field>
+        <field name="type">ir.actions.server</field>
+        <field name="model_id" ref="event.model_event_event"/>
+        <field name="binding_model_id" ref="event.model_event_event"/>
+        <field name="state">code</field>
+        <field name="code">
+            if records:
+                action = records.confirm_registrations()
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Fixes https://github.com/odoo-cae/odoo-addons-hr-incubator/issues/52

- Fixes importing event's and event registrations by removing the `readonly` property of the `state` field. Normally, this needs to be compensated by adding a `readonly` restriction in the form views, but in both modules the `state` field only occurs in the `statusbar` which is `readonly` by default.
- Adds action on events to confirm all there registrations at once. Note that we have to loop over registrations since the `confirm_registration()` function is `@api.one`