### PR TITLE
Use super() in case of single inheritance

### DIFF
--- a/coopaname_custom/models/event.py
+++ b/coopaname_custom/models/event.py
@@ -103,7 +103,7 @@ class Event(models.Model):
 
     @api.model
     def create(self, vals):
-        event = super(Event, self).create(vals)
+        event = super().create(vals)
         if "organizer_id" in vals:
             event.sync_organizer_registrations(vals["organizer_id"])
         if "co_organizer_id" in vals:
@@ -116,5 +116,5 @@ class Event(models.Model):
             self.sync_organizer_registrations(vals["organizer_id"])
         if "co_organizer_id" in vals:
             self.sync_co_organizer_registrations(vals["co_organizer_id"])
-        res = super(Event, self).write(vals)
+        res = super().write(vals)
         return res

--- a/coopaname_custom/models/hr_applicant.py
+++ b/coopaname_custom/models/hr_applicant.py
@@ -10,7 +10,7 @@ class Applicant(models.Model):
 
     @api.onchange("partner_id")
     def onchange_partner_id(self):
-        res = super(Applicant, self).onchange_partner_id()
+        res = super().onchange_partner_id()
         self.name = self.partner_id.name
         self.partner_name = self.partner_id.name
         return res

--- a/member_data_history/README.rst
+++ b/member_data_history/README.rst
@@ -74,7 +74,7 @@ To log a value change, overload `write` like this
                         "new_value": str(vals.get("zip")),
                     }
                 )
-            return super(ResPartner, self).write(vals)
+            return super().write(vals)
 
 If you need to log a value on creation, overwrite `create(vals)`.
 

--- a/member_data_history/models/hr_contract.py
+++ b/member_data_history/models/hr_contract.py
@@ -45,4 +45,4 @@ class HRContract(models.Model):
                     "new_value": vals.get("date_end"),
                 }
             )
-        return super(HRContract, self).write(vals)
+        return super().write(vals)

--- a/member_data_history/models/hr_employee.py
+++ b/member_data_history/models/hr_employee.py
@@ -52,7 +52,7 @@ class Employee(models.Model):
                     "new_value": partner.zip,
                 }
             )
-        return super(Employee, self).write(vals)
+        return super().write(vals)
 
     @api.depends("address_home_id.zip")
     def _compute_trigger(self):

--- a/member_data_history/models/res_partner.py
+++ b/member_data_history/models/res_partner.py
@@ -20,4 +20,4 @@ class ResPartner(models.Model):
                     "new_value": str(vals.get("zip")),
                 }
             )
-        return super(ResPartner, self).write(vals)
+        return super().write(vals)

--- a/member_data_history/readme/USAGE.rst
+++ b/member_data_history/readme/USAGE.rst
@@ -41,6 +41,6 @@ To log a value change, overload `write` like this
                         "new_value": str(vals.get("zip")),
                     }
                 )
-            return super(ResPartner, self).write(vals)
+            return super().write(vals)
 
 If you need to log a value on creation, overwrite `create(vals)`.

--- a/member_data_history/tests/test_value_log.py
+++ b/member_data_history/tests/test_value_log.py
@@ -10,7 +10,7 @@ from odoo import tests
 class TestValueLog(tests.common.TransactionCase):
     def setUp(self):
 
-        super(TestValueLog, self).setUp()
+        super().setUp()
 
         self.employee = self.browse_ref("hr.employee_al")
 


### PR DESCRIPTION
Python3 is behind us, in case of single inheritance `super()` is totally enough, at least only in python code glad to hear if there is some corner-case related to Odoo to keep in mind!