### PR TITLE
Test, doc and refactoring for _format_phone_number

### DIFF
--- a/coopaname_custom/models/hr_employee.py
+++ b/coopaname_custom/models/hr_employee.py
@@ -13,7 +13,10 @@ from odoo.exceptions import ValidationError
 _logger = logging.getLogger(__name__)
 
 
-def _format_phone_number(number):
+def _format_phone_number(number: str) -> str:
+    """Format a given phone number into a standardized one.
+    Special case numbers with +33 indicator (france) are rendered
+    as national numbers without international prefix."""
     number = phonenumbers.parse(number, "FR")
     if number.country_code == 33:
         return phonenumbers.format_number(

--- a/coopaname_custom/models/hr_employee.py
+++ b/coopaname_custom/models/hr_employee.py
@@ -9,6 +9,7 @@ import phonenumbers
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from phonenumbers import PhoneNumberFormat
 
 _logger = logging.getLogger(__name__)
 
@@ -18,14 +19,13 @@ def _format_phone_number(number: str) -> str:
     Special case numbers with +33 indicator (france) are rendered
     as national numbers without international prefix."""
     number = phonenumbers.parse(number, "FR")
-    if number.country_code == 33:
-        return phonenumbers.format_number(
-            number, phonenumbers.PhoneNumberFormat.NATIONAL
-        )
-    else:
-        return phonenumbers.format_number(
-            number, phonenumbers.PhoneNumberFormat.INTERNATIONAL
-        )
+    formatter = (
+        PhoneNumberFormat.NATIONAL
+        if number.country_code == 33
+        else PhoneNumberFormat.INTERNATIONAL
+    )
+
+    return phonenumbers.format_number(number, formatter)
 
 
 class Employee(models.Model):

--- a/coopaname_custom/tests/test_coopaname_custom.py
+++ b/coopaname_custom/tests/test_coopaname_custom.py
@@ -21,10 +21,23 @@ class TestCoopanameCustom(TransactionCase):
         self.assertEquals(applicant.partner_name, partner.name)
 
     def test_format_phone_number(self):
+        number_inter_fr06 = "+33699687678"
+        number_inter_fr07 = "+33799687678"
+
+        alice = self.env["hr.employee"].create(
+            {
+                "firstname": "Alice",
+                "lastname": "Rustacean",
+                "mobile_phone": number_inter_fr06,
+                "work_phone": number_inter_fr07,
+            }
+        )
+
+        self.assertEqual(alice.mobile_phone, "06 99 68 76 78")
+        self.assertEqual(alice.work_phone, "07 99 68 76 78")
 
         number_fr = "0699687678"
         number_be = "+32 4888657 50"
-
         ernest = self.env["hr.employee"].create(
             {
                 "firstname": "Ernest",


### PR DESCRIPTION
Added documentation, types, a test to check international number stripping in case of `+33` prefix and a little refactoring because multi-return was not obliged.

Used [black](https://github.com/psf/black) for code formatting of `_format_phone_number` function