### PR TITLE
[hr_cae_contract] Fix failure in CI in i18n.

### DIFF
--- a/hr_cae_contract/i18n/fr.po
+++ b/hr_cae_contract/i18n/fr.po
@@ -478,7 +478,7 @@ msgstr "Contrats de résiliation"
 #: code:addons/hr_cae_contract/models/hr_contract.py:381
 #, python-format
 msgid "The maximum amount of %s contracts of type '%s' has been reached"
-msgstr "Le montant maximal des %s contrats de type "%s" a été atteint"
+msgstr "Le montant maximal des %s contrats de type '%s' a été atteint"
 
 #. module: hr_cae_contract
 #: code:addons/hr_cae_contract/models/hr_contract.py:398


### PR DESCRIPTION
Related failure who pointed it totally indirectly (failure due to flake8 who didn't wanted to know about `__future__ import annotation`)
<https://travis-ci.org/github/odoo-cae/odoo-addons-hr-incubator/jobs/743385751#L325>
Lint ErrorError from pylint:
```
hr_cae_contract/i18n/fr.po:1: [E7912(po-syntax-error), ]  
Syntax error in po file (line 481): unescaped double quote found
```